### PR TITLE
GitHub Organizationドメイン検証用のTXTレコードを追加

### DIFF
--- a/modules/aws/github/main.tf
+++ b/modules/aws/github/main.tf
@@ -1,0 +1,11 @@
+data "aws_route53_zone" "main" {
+  name = var.main_domain_name
+}
+
+resource "aws_route53_record" "github_text" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "_github-challenge-nekochans"
+  type    = "TXT"
+  records = var.github_txt_records
+  ttl     = "900"
+}

--- a/modules/aws/github/variables.tf
+++ b/modules/aws/github/variables.tf
@@ -1,0 +1,13 @@
+variable "main_domain_name" {
+  description = "portfolio DomainName"
+  type        = string
+  default     = "nekochans.org"
+}
+
+variable "github_txt_records" {
+  type = list(string)
+
+  default = [
+    "780c9a5b36",
+  ]
+}

--- a/providers/aws/environments/prod/10-github/backend.tf
+++ b/providers/aws/environments/prod/10-github/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "prod-nekochans-portfolio-tfstate"
+    key     = "github/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "nekochans-portfolio"
+  }
+}

--- a/providers/aws/environments/prod/10-github/main.tf
+++ b/providers/aws/environments/prod/10-github/main.tf
@@ -1,0 +1,3 @@
+module "github" {
+  source = "../../../../../modules/aws/github"
+}

--- a/providers/aws/environments/prod/10-github/provider.tf
+++ b/providers/aws/environments/prod/10-github/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "nekochans-portfolio"
+}

--- a/providers/aws/environments/prod/10-github/versions.tf
+++ b/providers/aws/environments/prod/10-github/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "0.12.25"
+
+  required_providers {
+    aws = "2.62.0"
+  }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/nekochans-terraform/issues/8

# Doneの定義
- https://github.com/nekochans/nekochans-terraform/issues/8 の完了条件を満たしている事

# 変更点概要
- https://help.github.com/ja/github/setting-up-and-managing-organizations-and-teams/verifying-your-organizations-domain の手順に従ってTXTレコードを追加

# 補足情報
TXTレコードは「Verified」バッジが表示されたら消しても問題ないらしい。
しかし今後また別のサービスのドメインを追加する可能性もあるので手順を整理する意味でも残しておく。